### PR TITLE
refactor(aerospace): migrate to native HM module

### DIFF
--- a/home/aerospace/default.nix
+++ b/home/aerospace/default.nix
@@ -1,20 +1,9 @@
 {
-  lib,
-  config,
-  pkgs,
-  ...
-}:
-let
-  toml = pkgs.formats.toml { };
-in
-{
-  options.programs.aerospace.settings = lib.mkOption {
-    type = toml.type;
-    default = { };
-  };
+  programs.aerospace = {
+    enable = true;
+    package = null;
 
-  config = {
-    programs.aerospace.settings = {
+    userSettings = {
       "after-login-command" = [ ];
       "after-startup-command" = [ ];
       "start-at-login" = true;
@@ -193,8 +182,5 @@ in
         }
       ];
     };
-
-    xdg.configFile."aerospace/aerospace.toml".source =
-      toml.generate "aerospace.toml" config.programs.aerospace.settings;
   };
 }


### PR DESCRIPTION
## Summary

- Replaces the custom \`programs.aerospace.settings\` option definition and manual \`xdg.configFile\` write with the built-in Home Manager \`programs.aerospace\` module
- Renames \`settings\` → \`userSettings\` to match the HM option name
- Adds \`enable = true\` and \`package = null\` (AeroSpace is installed via Homebrew, not Nix)
- Adds \`.gitignore\` to exclude \`tmp/\` (used for the local Home Manager reference clone)

## Test plan

- [ ] \`make check\` passes
- [ ] \`sudo make\` applies cleanly
- [ ] AeroSpace config reloads correctly (\`alt-shift-semicolon\` → \`esc\`)