### PR TITLE
refactor(mise): migrate to programs.mise.globalConfig

### DIFF
--- a/home/mise/default.nix
+++ b/home/mise/default.nix
@@ -1,54 +1,62 @@
 {
-  lib,
-  config,
-  pkgs,
-  ...
-}:
-let
-  toml = pkgs.formats.toml { };
-in
-{
-  options.programs.mise.managedConfig = {
-    tools = lib.mkOption {
-      type = lib.types.attrsOf lib.types.str;
-      default = { };
+  programs.mise = {
+    enable = true;
+
+    globalConfig = {
+      settings = {
+        idiomatic_version_file_enable_tools = [
+          "go"
+          "java"
+          "opentofu"
+          "python"
+          "ruby"
+          "terraform"
+          "yarn"
+        ];
+        ruby.compile = false;
+      };
+
+      tools = {
+        bun = "latest";
+        commitlint-rs = "latest";
+        java = "latest";
+        lefthook = "latest";
+        node = "latest";
+        opentofu = "latest";
+        prek = "latest";
+        ruby = "latest";
+        terraform = "latest";
+        uv = "latest";
+
+        "npm:@github/copilot" = "latest";
+        "npm:@pnpm/exe" = "latest";
+        "npm:npm-check-updates" = "latest";
+        "npm:prettier" = "latest";
+        "npm:prettier-plugin-sort-json" = "latest";
+        "npm:typescript-language-server" = "latest";
+      };
     };
   };
 
-  config = {
-    programs.mise = {
-      enable = true;
-    };
-
-    programs.mise.managedConfig.tools = {
-      commitlint-rs = "latest";
-      lefthook = "latest";
-    };
-
-    programs.fish.shellAbbrs = {
-      m = "mise";
-      ma = "mise alias";
-      mb = "mise backends";
-      mcfg = "mise config";
-      mdr = "mise doctor";
-      me = "mise env";
-      mfmt = "mise fmt";
-      mi = "mise install";
-      mln = "mise link";
-      mls = "mise list";
-      mps = "mise plugins";
-      mr = "mise run";
-      mrm = "mise unuse";
-      msh = "mise shell";
-      mt = "mise tasks";
-      mu = "mise use";
-      mup = "mise upgrade";
-      mw = "mise watch";
-      mx = "mise exec --";
-    };
-
-    xdg.configFile."mise/config.toml".source = toml.generate "mise-config.toml" {
-      tools = config.programs.mise.managedConfig.tools;
-    };
+  programs.fish.shellAbbrs = {
+    m = "mise";
+    ma = "mise alias";
+    mb = "mise backends";
+    mcfg = "mise config";
+    mdr = "mise doctor";
+    me = "mise env";
+    mfmt = "mise fmt";
+    mi = "mise install";
+    mln = "mise link";
+    mls = "mise list";
+    mps = "mise plugins";
+    mr = "mise run";
+    mrm = "mise unuse";
+    msh = "mise shell";
+    mt = "mise tasks";
+    mu = "mise use";
+    mup = "mise upgrade";
+    mw = "mise watch";
+    mx = "mise exec --";
   };
 }


### PR DESCRIPTION
## Summary

- Replaces the custom \`programs.mise.managedConfig\` option definition and manual \`xdg.configFile\` write with the built-in Home Manager \`programs.mise.globalConfig\`
- Drops the \`let toml\` block and \`pkgs\`/\`lib\`/\`config\` module arguments — no longer needed
- Module shrinks from 54 lines to 32

## Test plan

- [ ] \`make check\` passes
- [ ] \`sudo make\` applies cleanly
- [ ] \`mise list\` shows commitlint-rs and lefthook after activation